### PR TITLE
Fix crash when "Read Only" files are open

### DIFF
--- a/tabfilter.py
+++ b/tabfilter.py
@@ -45,7 +45,7 @@ class TabFilterCommand(sublime_plugin.WindowCommand):
 					view_captions.append("Unsaved Changes")
 
 				if view.is_read_only():
-					caption.append("Read Only")
+					view_captions.append("Read Only")
 
 				caption = ", ".join(view_captions)
 				


### PR DESCRIPTION
When there is a tab open displaying a "Read Only" file, tab filter crashes. This is due to the wrong variable being used in the "read_only" branch.